### PR TITLE
WEB-6952: Fix for ANS logs.

### DIFF
--- a/modules/o2e_obe_salesforce/src/AreaVerificationService.php
+++ b/modules/o2e_obe_salesforce/src/AreaVerificationService.php
@@ -162,10 +162,7 @@ class AreaVerificationService {
       ]);
       return $result;
     }
-    catch (RequestException $e) {
-      $this->obeSfLogger->log('Salesforce - VerifyAreaServiced Fail', 'error', $e->getMessage());
-      // Datadog
-      $this->dataDogService->createFailDatadog('Salesforce - VerifyAreaServiced Fail', 'GET', $api_url, $e ); 
+    catch (RequestException $e) {    
       if (!empty($e->getResponse())) {
         // Tempstore to store areaverification request log.
         $tempstore->set('areaverification', [
@@ -173,6 +170,18 @@ class AreaVerificationService {
           'request' => $request,
           'response' => $e->getResponseBodySummary($e->getResponse()),
         ]);
+        $tempstore->set('response', [
+          'service_id' => '',
+          'from_postal_code' => $zipcode,
+          'franchise_id' => '',
+          'franchise_name' => '',
+          'job_duration' => '',
+          'lastServiceTime' => '',
+          'state' => '',
+        ]);
+        $this->obeSfLogger->log('Salesforce - VerifyAreaServiced Fail', 'error', $e->getMessage());
+        // Datadog
+        $this->dataDogService->createFailDatadog('Salesforce - VerifyAreaServiced Fail', 'GET', $api_url, $e ); 
         return [
           'code' => $e->getCode(),
           'message' => $e->getResponseBodySummary($e->getResponse()),


### PR DESCRIPTION
Ticket : https://o2ebrands.atlassian.net/browse/WEB-6952
Descriptin : In Datadogservice createFailDatadog function tmpstore value for zipcode is missing.For the fix we are creating tempstore in catch block with single parameter zipcode.
` $tempstore->set('response', [
          'service_id' => '',
          'from_postal_code' => $zipcode,
          'franchise_id' => '',
          'franchise_name' => '',
          'job_duration' => '',
          'lastServiceTime' => '',
          'state' => '',
        ]);`